### PR TITLE
Run insertion of room in the same transaction that inserts events

### DIFF
--- a/data/events/src/jvmTest/kotlin/com/addhen/fosdem/data/events/database/EventsDbDaoTest.kt
+++ b/data/events/src/jvmTest/kotlin/com/addhen/fosdem/data/events/database/EventsDbDaoTest.kt
@@ -15,6 +15,7 @@ import com.addhen.fosdem.test.day2
 import com.addhen.fosdem.test.day2Event
 import com.addhen.fosdem.test.day3Event
 import com.addhen.fosdem.test.events
+import com.addhen.fosdem.test.room
 import com.addhen.fosdem.test.setDurationTime
 import com.addhen.fosdem.test.setRoomId
 import kotlinx.coroutines.flow.first
@@ -26,7 +27,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
 class EventsDbDaoTest : BaseDatabaseTest() {
-
   @JvmField
   @RegisterExtension
   val coroutineTestRule = CoroutineTestRule()
@@ -39,129 +39,154 @@ class EventsDbDaoTest : BaseDatabaseTest() {
   }
 
   @Test
-  fun `successfully gets events by date one from the database`() = coroutineTestRule.runTest {
-    // Seed some data
-    givenDaysAndEventsData()
+  fun `successfully gets events by date one from the database`() =
+    coroutineTestRule.runTest {
+      // Seed some data
+      givenDaysAndEventsData()
 
-    val actual = sut.getEvents(day.date).first()
+      val actual = sut.getEvents(day.date).first()
 
-    assertEquals(1, actual.size)
-    val expectedEvent = events.first()
-    assertEquals(listOf(expectedEvent.setDurationTime()), actual)
-  }
-
-  @Test
-  fun `successfully gets events by day two from the database`() = coroutineTestRule.runTest {
-    // Seed some data
-    givenDaysAndEventsData()
-
-    val actual = sut.getEvents(day2.date).first()
-
-    assertEquals(2, actual.size)
-
-    val expectedDay2Event1 = day2Event.setDurationTime().setRoomId()
-    val expectedDay2Event2 = day3Event.setDurationTime()
-    assertEquals(listOf(expectedDay2Event2, expectedDay2Event1), actual)
-  }
+      assertEquals(1, actual.size)
+      val expectedEvent = events.first()
+      assertEquals(listOf(expectedEvent.setDurationTime()), actual)
+    }
 
   @Test
-  fun `successfully gets events by id`() = coroutineTestRule.runTest {
-    // Seed some data
-    givenDaysAndEventsData()
+  fun `successfully gets events by day two from the database`() =
+    coroutineTestRule.runTest {
+      // Seed some data
+      givenDaysAndEventsData()
 
-    val actual = sut.getEvent(3).first()
+      val actual = sut.getEvents(day2.date).first()
 
-    val expectedEvent = events.last()
-    assertEquals(
-      expectedEvent.copy(
-        duration = expectedEvent.start_time + expectedEvent.duration,
-      ),
-      actual,
-    )
-  }
+      assertEquals(2, actual.size)
 
-  @Test
-  fun `successfully toggles event isBookmarked field to true`() = coroutineTestRule.runTest {
-    // Seed some data
-    givenDaysAndEventsData()
-
-    sut.toggleBookmark(3)
-    val actual = sut.getEvent(3).first()
-
-    assertEquals(true, actual.isBookmarked)
-  }
+      val expectedDay2Event1 = day2Event.setDurationTime().setRoomId()
+      val expectedDay2Event2 = day3Event.setDurationTime()
+      assertEquals(listOf(expectedDay2Event2, expectedDay2Event1), actual)
+    }
 
   @Test
-  fun `successfully toggles event isBookmarked field to false`() = coroutineTestRule.runTest {
-    // Seed some data
-    givenDaysAndEventsData()
+  fun `successfully gets events by id`() =
+    coroutineTestRule.runTest {
+      // Seed some data
+      givenDaysAndEventsData()
 
-    sut.toggleBookmark(3) // Initial toggle state is false, this call toggles it to true
-    sut.toggleBookmark(3) // Now toggle it back to false
-    val actual = sut.getEvent(3).first()
+      val actual = sut.getEvent(3).first()
 
-    assertEquals(false, actual.isBookmarked)
-  }
-
-  @Test
-  fun `successfully deletes all events related data`() = coroutineTestRule.runTest {
-    // Seed some data
-    givenDaysAndEventsData()
-
-    sut.deleteRelatedData()
-
-    val actual = sut.getEvents(day.date).first()
-    val days = sut.getDays()
-
-    // assertEquals(true, actual.isEmpty())
-    assertEquals(true, actual.isNotEmpty())
-    assertEquals(true, days.isNotEmpty())
-    assertEvents(actual)
-  }
+      val expectedEvent = events.last()
+      assertEquals(
+        expectedEvent.copy(
+          duration = expectedEvent.start_time + expectedEvent.duration,
+        ),
+        actual,
+      )
+    }
 
   @Test
-  fun `successfully gets all bookmarked events`() = runTest {
-    // Seed some data
-    val event = day1Event.copy(isBookmarked = true)
-    val event2 = day2Event.copy(isBookmarked = true)
-    val inputEvents = listOf(event, event2)
-    val expected = listOf(
-      event,
-      event2.setRoomId(), // Change event2 room id to 1 as room name is unique
-    ).setDurationTime()
-    givenDaysAndEventsData(inputEvents)
+  fun `successfully toggles event isBookmarked field to true`() =
+    coroutineTestRule.runTest {
+      // Seed some data
+      givenDaysAndEventsData()
 
-    val actual = sut.getAllBookmarkedEvents().first()
-    assertEquals(expected, actual)
-  }
+      sut.toggleBookmark(3)
+      val actual = sut.getEvent(3).first()
+
+      assertEquals(true, actual.isBookmarked)
+    }
 
   @Test
-  fun `successfully gets an empty bookmarked events`() = coroutineTestRule.runTest {
-    // Seed some data
-    val event = day1Event.copy(isBookmarked = false)
-    val event2 = day2Event.copy(isBookmarked = false)
-    val events = listOf(event, event2)
-    givenDaysAndEventsData(events)
+  fun `successfully toggles event isBookmarked field to false`() =
+    coroutineTestRule.runTest {
+      // Seed some data
+      givenDaysAndEventsData()
 
-    val actual = sut.getAllBookmarkedEvents().first()
+      sut.toggleBookmark(3) // Initial toggle state is false, this call toggles it to true
+      sut.toggleBookmark(3) // Now toggle it back to false
+      val actual = sut.getEvent(3).first()
 
-    assertEquals(true, actual.isEmpty())
-  }
+      assertEquals(false, actual.isBookmarked)
+    }
 
   @Test
-  fun `successfully adds days and gets all the added days`() = coroutineTestRule.runTest {
-    val date1 = "2023-02-16"
-    val date2 = "2023-02-17"
-    val days = listOf(
-      DayEntity(1, LocalDate.parse(date1)),
-      DayEntity(2, LocalDate.parse(date2)),
-    )
+  fun `successfully deletes all events related data`() =
+    coroutineTestRule.runTest {
+      // Seed some data
+      givenDaysAndEventsData()
 
-    sut.addDays(days)
-    val actual = sut.getDays()
+      sut.deleteRelatedData()
 
-    assertEquals(days, actual)
-  }
+      val actual = sut.getEvents(day.date).first()
+      val days = sut.getDays()
+
+      // assertEquals(true, actual.isEmpty())
+      assertEquals(true, actual.isNotEmpty())
+      assertEquals(true, days.isNotEmpty())
+      assertEvents(actual)
+    }
+
+  @Test
+  fun `successfully gets all bookmarked events`() =
+    runTest {
+      // Seed some data
+      val event = day1Event.copy(isBookmarked = true)
+      val event2 = day2Event.copy(isBookmarked = true)
+      val inputEvents = listOf(event, event2)
+      val expected =
+        listOf(
+          event,
+          event2.setRoomId(), // Change event2 room id to 1 as room name is unique
+        ).setDurationTime()
+      givenDaysAndEventsData(inputEvents)
+
+      val actual = sut.getAllBookmarkedEvents().first()
+      assertEquals(expected, actual)
+    }
+
+  @Test
+  fun `successfully gets an empty bookmarked events`() =
+    coroutineTestRule.runTest {
+      // Seed some data
+      val event = day1Event.copy(isBookmarked = false)
+      val event2 = day2Event.copy(isBookmarked = false)
+      val events = listOf(event, event2)
+      givenDaysAndEventsData(events)
+
+      val actual = sut.getAllBookmarkedEvents().first()
+
+      assertEquals(true, actual.isEmpty())
+    }
+
+  @Test
+  fun `successfully adds days and gets all the added days`() =
+    coroutineTestRule.runTest {
+      val date1 = "2023-02-16"
+      val date2 = "2023-02-17"
+      val days =
+        listOf(
+          DayEntity(1, LocalDate.parse(date1)),
+          DayEntity(2, LocalDate.parse(date2)),
+        )
+
+      sut.addDays(days)
+      val actual = sut.getDays()
+
+      assertEquals(days, actual)
+    }
+
+  @Test
+  fun `successfully adds events and gets all the added events`() =
+    coroutineTestRule.runTest {
+      val event1 = day1Event.copy(room = room.copy(id = 2))
+      val event2 = day2Event.copy(room = room.copy(id = 2))
+      val events = listOf(event1, event2)
+      sut.addDays(listOf(day, day2))
+
+      sut.insert(events)
+      val actual = sut.getEvents().first()
+
+      assertEquals(events.setDurationTime(), actual)
+    }
 
   private suspend fun givenDaysAndEventsData(inputEvents: List<EventEntity> = events) {
     sut.addDays(listOf(day, day2))

--- a/data/sqldelight/src/iosMain/kotlin/com/addhen/fosdem/data/sqldelight/database/IosSqlDriverFactory.kt
+++ b/data/sqldelight/src/iosMain/kotlin/com/addhen/fosdem/data/sqldelight/database/IosSqlDriverFactory.kt
@@ -10,5 +10,10 @@ import com.addhen.fosdem.data.sqldelight.api.Constants
 import com.addhen.fosdem.data.sqldelight.api.SqlDriverFactory
 
 class IosSqlDriverFactory : SqlDriverFactory {
-  override fun createDriver(): SqlDriver = NativeSqliteDriver(Database.Schema, Constants.DB_NAME)
+  override fun createDriver(): SqlDriver =
+    NativeSqliteDriver(
+      Database.Schema,
+      Constants.DB_NAME,
+      maxReaderConnections = 4,
+    )
 }

--- a/ios-app/Fosdem/Fosdem.xcodeproj/xcuserdata/eyedol.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios-app/Fosdem/Fosdem.xcodeproj/xcuserdata/eyedol.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>SchemeUserState</key>
 	<dict>
-		<key>Fosdem.xcscheme_^#shared#^_</key>
+		<key>Fosdem.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
 			<integer>0</integer>


### PR DESCRIPTION

## Issue
- closes #188 

## Overview (Required)
- Run insertion of room in the same database transaction that inserts events this allows the last row id to be returned when a room is inserted. This fixed the crashed encountered when the app is run on iOS.
- Apply spotless task to fix code style issues.

