### PR TITLE
Implement a share sheet for iOS

### DIFF
--- a/feature-ui/main/src/iosMain/kotlin/com/addhen/fosdem/ui/main/MainUiViewController.kt
+++ b/feature-ui/main/src/iosMain/kotlin/com/addhen/fosdem/ui/main/MainUiViewController.kt
@@ -31,6 +31,7 @@ import platform.SafariServices.SFSafariViewController
 import platform.UIKit.NSCharacterEncodingDocumentAttribute
 import platform.UIKit.NSDocumentTypeDocumentAttribute
 import platform.UIKit.NSHTMLTextDocumentType
+import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIAlertAction
 import platform.UIKit.UIAlertActionStyleCancel
 import platform.UIKit.UIAlertActionStyleDefault
@@ -66,7 +67,7 @@ fun MainUiViewController(
       val safari = SFSafariViewController(NSURL(string = url))
       uiViewController.presentViewController(safari, animated = true, completion = null)
     },
-    { /* Implement sharing of event details */ },
+    { info -> uiViewController.shareInfo(info) },
     { title, room, description, startAtMillSeconds, endAtMillSeconds ->
       uiViewController.saveEventToCalendar(
         appStrings,
@@ -79,6 +80,16 @@ fun MainUiViewController(
     },
     Modifier,
   )
+}
+
+private fun UIViewController.shareInfo(shareInfo: String) {
+  if (shareInfo.isEmpty()) return
+  val parsedHtmlInfo = parseHtml(shareInfo)
+  val activityViewController = UIActivityViewController(
+    activityItems = listOf(parsedHtmlInfo),
+    applicationActivities = null,
+  )
+  presentViewController(activityViewController, animated = true, completion = null)
 }
 
 private fun UIViewController.saveEventToCalendar(

--- a/feature-ui/main/src/iosMain/kotlin/com/addhen/fosdem/ui/main/MainUiViewController.kt
+++ b/feature-ui/main/src/iosMain/kotlin/com/addhen/fosdem/ui/main/MainUiViewController.kt
@@ -69,7 +69,7 @@ fun MainUiViewController(
     },
     { info -> uiViewController.shareInfo(info) },
     { title, room, description, startAtMillSeconds, endAtMillSeconds ->
-      uiViewController.saveEventToCalendar(
+      uiViewController.launchCalendar(
         appStrings,
         title,
         room,
@@ -92,7 +92,7 @@ private fun UIViewController.shareInfo(shareInfo: String) {
   presentViewController(activityViewController, animated = true, completion = null)
 }
 
-private fun UIViewController.saveEventToCalendar(
+private fun UIViewController.launchCalendar(
   appStrings: AppStrings,
   title: String,
   room: String,


### PR DESCRIPTION
This will allow to share event info on iOS

## Issue
- closes #205 

## Overview (Required)
- Used `UIActivityViewController` to show a share sheet for the user to share an event info

## Movie (Optional)
|            After            |
|:---------------------------:|
| <video src="https://github.com/eyedol/fosdem-event-app/assets/73175/e9bab533-6dc5-40d3-8156-4c50c6f513c4" width="300" > |



